### PR TITLE
Handle multiple includes

### DIFF
--- a/lib_files/src/Matter.h
+++ b/lib_files/src/Matter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define CHIP_HAVE_CONFIG_H true
 #define CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER <lib/address_resolve/AddressResolve_DefaultImpl.h>
 

--- a/lib_files/src/esp32-arduino-matter_patches_arduino.h
+++ b/lib_files/src/esp32-arduino-matter_patches_arduino.h
@@ -1,3 +1,4 @@
+#pragma once
 
 // use some method from esp32-hal-bt.c to force linking it
 // and so that it will override btInUse method in esp32-hal-misc.c 


### PR DESCRIPTION
The current headers don't `#ifndef` / `#pragma once` so they can't be included multiple times.

Minor fix/change to throw a `#pragma once` in to avoid that issue. I went the `#pragma` route because the first other header I opened (`endpoint_config.h`) was using pragma vs ifndef.